### PR TITLE
Bump mongodb and mongoose in /atm-locator

### DIFF
--- a/atm-locator/package-lock.json
+++ b/atm-locator/package-lock.json
@@ -17,7 +17,7 @@
         "express-async-handler": "^1.2.0",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.0",
-        "mongoose": "^7.2.4",
+        "mongoose": "^7.5.0",
         "morgan": "^1.10.0",
         "nodemon": "^2.0.22",
         "swagger-jsdoc": "^6.2.8",
@@ -69,15 +69,24 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.0",
@@ -205,9 +214,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
-      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "engines": {
         "node": ">=14.20.1"
       }
@@ -894,11 +903,11 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.5.0.tgz",
-      "integrity": "sha512-XgrkUgAAdfnZKQfk5AsYL8j7O99WHd4YXPxYxnh8dZxD+ekYWFRA3JktUsBnfg+455Smf75/+asoU/YLwNGoQQ==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "dependencies": {
-        "bson": "^5.3.0",
+        "bson": "^5.4.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -906,15 +915,23 @@
         "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.3"
+        "@mongodb-js/saslprep": "^1.1.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
         "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
           "optional": true
         },
         "mongodb-client-encryption": {
@@ -935,13 +952,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.2.4.tgz",
-      "integrity": "sha512-BWcgShV2WH1rspICiJKLPi7QssTebpGJ23Nyk7qG0TMEE/OEAlsQKEhI7VlrXg4ZnoOcHgG+N+upW9tj17TTQg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.5.0.tgz",
+      "integrity": "sha512-FpOWOb0AJuaVcplmEyIJ2eCbVGe4gOoniPD+pmft5BrGrNrsFcnYXlERdXtBApGHMHPwD7WbxTyhCbUNr72F3Q==",
       "dependencies": {
-        "bson": "^5.3.0",
+        "bson": "^5.4.0",
         "kareem": "2.5.1",
-        "mongodb": "5.5.0",
+        "mongodb": "5.8.1",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -1285,18 +1302,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/semver": {
       "version": "7.5.1",

--- a/atm-locator/package.json
+++ b/atm-locator/package.json
@@ -20,7 +20,7 @@
     "express-async-handler": "^1.2.0",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.0",
-    "mongoose": "^7.2.4",
+    "mongoose": "^7.5.0",
     "morgan": "^1.10.0",
     "nodemon": "^2.0.22",
     "swagger-jsdoc": "^6.2.8",


### PR DESCRIPTION
Bumps [mongodb](https://github.com/mongodb/node-mongodb-native) to 5.8.1 and updates ancestor dependency [mongoose](https://github.com/Automattic/mongoose). These dependencies need to be updated together.


Updates `mongodb` from 5.5.0 to 5.8.1
- [Release notes](https://github.com/mongodb/node-mongodb-native/releases)
- [Changelog](https://github.com/mongodb/node-mongodb-native/blob/v5.8.1/HISTORY.md)
- [Commits](https://github.com/mongodb/node-mongodb-native/compare/v5.5.0...v5.8.1)

Updates `mongoose` from 7.2.4 to 7.5.0
- [Release notes](https://github.com/Automattic/mongoose/releases)
- [Changelog](https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md)
- [Commits](https://github.com/Automattic/mongoose/compare/7.2.4...7.5.0)

---
updated-dependencies:
- dependency-name: mongodb dependency-type: indirect
- dependency-name: mongoose dependency-type: direct:production ...